### PR TITLE
Allow file to be passed in via stdin

### DIFF
--- a/reviser/reviser.go
+++ b/reviser/reviser.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"io"
 	"io/ioutil"
 	"path"
 	"sort"
@@ -56,8 +57,8 @@ func (o Options) shouldUseAliasForVersionSuffix() bool {
 }
 
 // Execute is for revise imports and format the code
-func Execute(projectName, filePath, localPkgPrefixes string, options ...Option) ([]byte, bool, error) {
-	originalContent, err := ioutil.ReadFile(filePath)
+func Execute(reader io.Reader, projectName, filePath, localPkgPrefixes string, options ...Option) ([]byte, bool, error) {
+	originalContent, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, false, err
 	}

--- a/reviser/reviser_test.go
+++ b/reviser/reviser_test.go
@@ -2,6 +2,7 @@ package reviser
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -343,7 +344,9 @@ import (
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			got, hasChange, err := Execute(tt.args.projectName, tt.args.filePath, "")
+			file, err := os.Open(tt.args.filePath)
+			assert.NoError(t, err)
+			got, hasChange, err := Execute(file, tt.args.projectName, tt.args.filePath, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -560,7 +563,9 @@ const webDirectory = "web"
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			got, hasChange, err := Execute(tt.args.projectName, tt.args.filePath, "", OptionRemoveUnusedImports)
+			file, err := os.Open(tt.args.filePath)
+			assert.NoError(t, err)
+			got, hasChange, err := Execute(file, tt.args.projectName, tt.args.filePath, "", OptionRemoveUnusedImports)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -661,7 +666,9 @@ func main() {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			got, hasChange, err := Execute(tt.args.projectName, tt.args.filePath, "", OptionUseAliasForVersionSuffix)
+			file, err := os.Open(tt.args.filePath)
+			assert.NoError(t, err)
+			got, hasChange, err := Execute(file, tt.args.projectName, tt.args.filePath, "", OptionUseAliasForVersionSuffix)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -866,7 +873,9 @@ func main() {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			got, hasChange, err := Execute(tt.args.projectName, tt.args.filePath, tt.args.localPkgPrefixes)
+			file, err := os.Open(tt.args.filePath)
+			assert.NoError(t, err)
+			got, hasChange, err := Execute(file, tt.args.projectName, tt.args.filePath, tt.args.localPkgPrefixes)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This adds additional compatibility with tools, like vscode, that don't have flexibility around how files to be formatted are specified to the underlying formater.

### Usage
```
cat main.go | goimports-reviser -file-path -
```

Using `-file-path -` forces the current working directory as the path to do projectName introspection, and output method to be stdout. 