### PR TITLE
Implement custom order for import groups.

### DIFF
--- a/pkg/grouporder/group_order.go
+++ b/pkg/grouporder/group_order.go
@@ -1,0 +1,69 @@
+package grouporder
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ImportGroupOrder represents order of import groups
+type ImportGroupOrder []Group
+
+// Group represents the name of import group
+type Group string
+
+var (
+	// GroupStd is std libs, e.g. fmt, errors, strings...
+	GroupStd Group = "std"
+	// GroupOrganization is packages that belong to the same organization
+	GroupOrganization Group = "org"
+	// GroupProject is packages that are inside the current project
+	GroupProject Group = "prj"
+	// GroupExternal is packages that are outside for example from github
+	GroupExternal Group = "ext"
+)
+
+const groupsCount = 4
+
+// NewImportGroupOrder creates new ImportGroupOrder from given string. String example: "std,ext,org,prj".
+func NewImportGroupOrder(s string) (ImportGroupOrder, error) {
+	groups := strings.Split(s, ",")
+	if len(groups) != groupsCount {
+		return nil, fmt.Errorf("the order list should contain %d items", groupsCount)
+	}
+
+	result := make([]Group, 0, groupsCount)
+	for _, g := range groups {
+		group := Group(g)
+		switch group {
+		case GroupStd, GroupOrganization, GroupProject, GroupExternal:
+		default:
+			return nil, fmt.Errorf("unknown group type '%s'", group)
+		}
+
+		result = append(result, group)
+	}
+
+	return result, nil
+}
+
+// GroupedImports returns ordered groups of imports.
+func (o ImportGroupOrder) GroupedImports(std, organization, project, external []string) [][]string {
+	result := make([][]string, 0, groupsCount)
+	for _, group := range o {
+		var imports []string
+		switch group {
+		case GroupStd:
+			imports = std
+		case GroupOrganization:
+			imports = organization
+		case GroupProject:
+			imports = project
+		case GroupExternal:
+			imports = external
+		}
+
+		result = append(result, imports)
+	}
+
+	return result
+}

--- a/pkg/grouporder/group_order_test.go
+++ b/pkg/grouporder/group_order_test.go
@@ -1,0 +1,80 @@
+package grouporder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewImportGroupOrder(t *testing.T) {
+	tests := map[string]struct {
+		str    string
+		expErr bool
+	}{
+		"valid": {
+			str:    "std,ext,org,prj",
+			expErr: false,
+		},
+		"not enough args": {
+			str:    "std,ext,org",
+			expErr: true,
+		},
+		"wrong arg": {
+			str:    "std,ext,org,unk",
+			expErr: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewImportGroupOrder(tt.str)
+			if (err != nil) != tt.expErr {
+				t.Errorf("NewImportGroupOrder() error = %v, wantErr %v", err, tt.expErr)
+				return
+			}
+		})
+	}
+}
+
+func TestImportGroupOrderGroupedImports(t *testing.T) {
+	tests := map[string]struct {
+		o        ImportGroupOrder
+		std      []string
+		org      []string
+		project  []string
+		external []string
+		exp      [][]string
+	}{
+		"default": {
+			o:        []Group{GroupStd, GroupExternal, GroupOrganization, GroupProject},
+			std:      []string{"1", "2", "3"},
+			org:      []string{"4"},
+			project:  []string{"5"},
+			external: []string{"6", "7"},
+			exp: [][]string{
+				{"1", "2", "3"},
+				{"6", "7"},
+				{"4"},
+				{"5"},
+			},
+		},
+		"reverse": {
+			o:        []Group{GroupProject, GroupOrganization, GroupExternal, GroupStd},
+			std:      []string{"1", "2", "3"},
+			org:      []string{"4"},
+			project:  []string{"5"},
+			external: []string{"6", "7"},
+			exp: [][]string{
+				{"5"},
+				{"4"},
+				{"6", "7"},
+				{"1", "2", "3"},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.o.GroupedImports(tt.std, tt.org, tt.project, tt.external); !reflect.DeepEqual(got, tt.exp) {
+				t.Errorf("GroupedImports() = %v, want %v", got, tt.exp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
These changes allow customizing the order of import groups.

Now there is an optional argument - `groups-order`, which has default order as the value (at first std, then external (general), organisation's (local) and project packages).

In my organization, I'm using a little bit different order of imports groups than the default one. 
The order that I'm interested in:
```
import (
   // stdlib

   // current project

   // organization's (local)

   // external (general)
)
```
So with argument `--groups-order="std,prj,org,ext"`, you can get the above order.