### PR TITLE
New features: Read from stdin, new -list, -write and -set-exit-status options (2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 reviser/testdata
 dist
 coverage.txt
+.idea/
+goimports-reviser
+
+

--- a/README.md
+++ b/README.md
@@ -36,16 +36,21 @@ Usage of goimports-reviser:
         File path to fix imports(ex.: ./reviser/reviser.go). Required parameter.
   -format
         Option will perform additional formatting. Optional parameter.
+  -list
+    	Option will list files whose formatting differs from goimports-reviser. Optional parameter.
   -local string
         Local package prefixes which will be placed after 3rd-party group(if defined). Values should be comma-separated. Optional parameters.
   -output string
-        Can be "file" or "stdout". Whether to write the formatted content back to the file or to stdout. Optional parameter. (default "file")
+        Can be "file", "write" or "stdout". Whether to write the formatted content back to the file or to stdout. When "write" together with "-list" will list the file name and write back to the file. Optional parameter. (default "file")
   -project-name string
         Your project name(ex.: github.com/incu6us/goimports-reviser). Optional parameter.
   -rm-unused
         Remove unused imports. Optional parameter.
   -set-alias
         Set alias for versioned package names, like 'github.com/go-pg/pg/v9'. In this case import will be set as 'pg "github.com/go-pg/pg/v9"'. Optional parameter.
+  -set-exit-status
+    	set the exit status to 1 if a change is needed/made. Optional parameter.
+
 ```
 
 ## Install

--- a/reviser/reviser.go
+++ b/reviser/reviser.go
@@ -9,6 +9,7 @@ import (
 	"go/printer"
 	"go/token"
 	"io/ioutil"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -19,6 +20,7 @@ import (
 
 const (
 	stringValueSeparator = ","
+	StandardInput        = "<standard-input>"
 )
 
 // Option is an int alias for options
@@ -70,7 +72,13 @@ func (o Options) shouldFormat() bool {
 
 // Execute is for revise imports and format the code
 func Execute(projectName, filePath, localPkgPrefixes string, options ...Option) ([]byte, bool, error) {
-	originalContent, err := ioutil.ReadFile(filePath)
+	var originalContent []byte
+	var err error
+	if filePath == StandardInput {
+		originalContent, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		originalContent, err = ioutil.ReadFile(filePath)
+	}
 	if err != nil {
 		return nil, false, err
 	}

--- a/reviser/reviser_test.go
+++ b/reviser/reviser_test.go
@@ -2,6 +2,7 @@ package reviser
 
 import (
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -383,7 +384,7 @@ import (
 )
 `,
 			},
-			want:       `package testdata
+			want: `package testdata
 
 /*
 #include <stdlib.h>
@@ -418,7 +419,7 @@ import "C"
 import "errors"
 `,
 			},
-			want:       `package testdata
+			want: `package testdata
 
 import (
 	"errors"
@@ -433,10 +434,30 @@ import "C"
 			wantChange: true,
 			wantErr:    false,
 		},
+		{
+			name: "try to read from stdin",
+			args: args{
+				projectName: "github.com/incu6us/goimports-reviser",
+				filePath:    StandardInput,
+				fileContent: ``,
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with non-existent file",
+			args: args{
+				projectName: "github.com/incu6us/goimports-reviser",
+				filePath:    "./testdatax/does-not-exist.go",
+				fileContent: ``,
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
-		if err := ioutil.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
-			t.Errorf("write test file failed: %s", err)
+		if tt.args.filePath != StandardInput && !strings.Contains(tt.args.filePath, "does-not-exist") {
+			if err := ioutil.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
+				t.Errorf("write test file failed: %s", err)
+			}
 		}
 
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
In order to make this utility usable as goimports is, added capabilities to:
 - read from stdin
 - just list the files which need formatting/sorting
 - return 1 to the shell so that it can stop a loop

You can now do things like:
$ echo $(git diff --cached --name-only --diff-filter=ACM | grep "\.go") | \
  xargs goimports-reviser -list -output write -file-path

or

$ git --no-pager show :"reviser/reviser.go" | goimports-reviser -list

or define a git alias like this:

goimportsrev = !echo $(git diff --cached --name-only --diff-filter=ACM | grep .go) \
               | xargs goimports-reviser -list -output write -file-path \
               | xargs git add

In a complex project, even though it does not have the possibility to
work on an entire subtree, it can be used with a Makefile to analyse the
subtree and stop on the first change needed.