### PR TITLE
Switch to Go 1.18 build tags (//go:build)

### DIFF
--- a/pkg/astutil/astutil.go
+++ b/pkg/astutil/astutil.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	buildTagPrefix = "+build"
+	buildTagPrefix = "//go:build "
 )
 
 // PackageImports is map of imports with their package names
@@ -97,10 +97,13 @@ func LoadPackageDependencies(dir, buildTag string) (PackageImports, error) {
 
 // ParseBuildTag parse `// +build ...` on a first line of *ast.File
 func ParseBuildTag(f *ast.File) string {
-	comments := f.Comments
-
-	if len(comments) > 0 && strings.Contains(comments[0].Text(), buildTagPrefix) {
-		return strings.TrimSpace(strings.Trim(comments[0].Text(), buildTagPrefix))
+	for _, g := range f.Comments {
+		for _, c := range g.List {
+			if !strings.HasPrefix(c.Text, buildTagPrefix) {
+				continue
+			}
+			return strings.TrimSpace(strings.TrimPrefix(c.Text, buildTagPrefix))
+		}
 	}
 
 	return ""

--- a/pkg/astutil/testdata/testdata.go
+++ b/pkg/astutil/testdata/testdata.go
@@ -1,4 +1,4 @@
-// +build test
+//go:build test
 
 package testdata
 


### PR DESCRIPTION
Hi @incu6us! First, thanks for this great tool! I started using it but I ran into an issue with Go 1.18. After investigation, I detected the problem and here is the PR to fix this.

### Overview

Currently, the [`goimports-reviser`](https://github.com/incu6us/goimports-reviser) cannot be executed against Go code in 1.18 that uses build tags. In such case, we got error:
```
-: build constraints exclude all Go files in /{redacted}/test/e2e
2022/07/15 00:36:22 package has an errors
main.main
	/Users/mszostok/workspace/go/src/github.com/goimports-reviser/main.go:175
runtime.main
	/usr/local/Cellar/go/1.18.2/libexec/src/runtime/proc.go:250
runtime.goexit
	/usr/local/Cellar/go/1.18.2/libexec/src/runtime/asm_amd64.s:1571
```

- This PR updates the logic responsible for adding those build tags.

### Investigation

The problem is that they removed support for `// +build` tags. According to the 1.18 release notes:

>**//go:build lines**
>
>
>Since the release of Go 1.18 marks the end of support for Go 1.16, all supported versions of Go now understand //go:build >lines. In Go 1.18, go fix now removes the now-obsolete // +build lines in modules declaring go 1.18 or later in their go.mod >files.
>
>For more information, see https://go.dev/design/draft-gobuild.

_source:  https://tip.golang.org/doc/go1.18_


