### PR TITLE
Remove deprecated stdlib functions

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -290,10 +289,10 @@ func main() {
 		cacheFile := path.Join(cacheDir, hex.EncodeToString(hash[:]))
 
 		var cacheContent, fileContent []byte
-		if cacheContent, err = ioutil.ReadFile(cacheFile); err == nil {
+		if cacheContent, err = os.ReadFile(cacheFile); err == nil {
 			// compare file content hash
 			var fileHashHex string
-			if fileContent, err = ioutil.ReadFile(originPath); err == nil {
+			if fileContent, err = os.ReadFile(originPath); err == nil {
 				fileHash := md5.Sum(fileContent)
 				fileHashHex = hex.EncodeToString(fileHash[:])
 			}
@@ -349,7 +348,7 @@ func resultPostProcess(hasChange bool, deprecatedMessagesCh chan string, originF
 			return
 		}
 
-		if err := ioutil.WriteFile(originFilePath, formattedOutput, 0644); err != nil {
+		if err := os.WriteFile(originFilePath, formattedOutput, 0644); err != nil {
 			log.Fatalf("failed to write fixed result to file(%s): %+v", originFilePath, errors.WithStack(err))
 		}
 		if *listFileName {

--- a/pkg/module/module.go
+++ b/pkg/module/module.go
@@ -1,7 +1,6 @@
 package module
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -14,7 +13,7 @@ const goModFilename = "go.mod"
 func Name(goModRootPath string) (string, error) {
 	goModFile := filepath.Join(goModRootPath, goModFilename)
 
-	data, err := ioutil.ReadFile(goModFile)
+	data, err := os.ReadFile(goModFile)
 	if err != nil {
 		return "", err
 	}

--- a/reviser/dir.go
+++ b/reviser/dir.go
@@ -2,7 +2,6 @@ package reviser
 
 import (
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -64,7 +63,7 @@ func (d *SourceDir) walk(options ...SourceFileOption) fs.WalkDirFunc {
 				return errors.WithStack(err)
 			}
 			if hasChange {
-				if err := ioutil.WriteFile(path, content, 0644); err != nil {
+				if err := os.WriteFile(path, content, 0644); err != nil {
 					log.Fatalf("failed to write fixed result to file(%s): %+v", path, errors.WithStack(err))
 				}
 			}

--- a/reviser/file.go
+++ b/reviser/file.go
@@ -8,7 +8,7 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"regexp"
@@ -61,9 +61,9 @@ func (f *SourceFile) Fix(options ...SourceFileOption) ([]byte, bool, error) {
 	var originalContent []byte
 	var err error
 	if f.filePath == StandardInput {
-		originalContent, err = ioutil.ReadAll(os.Stdin)
+		originalContent, err = io.ReadAll(os.Stdin)
 	} else {
-		originalContent, err = ioutil.ReadFile(f.filePath)
+		originalContent, err = os.ReadFile(f.filePath)
 	}
 	if err != nil {
 		return nil, false, err

--- a/reviser/file_test.go
+++ b/reviser/file_test.go
@@ -1,7 +1,7 @@
 package reviser
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -569,7 +569,7 @@ import "C"
 	}
 	for _, tt := range tests {
 		if tt.args.filePath != StandardInput && !strings.Contains(tt.args.filePath, "does-not-exist") {
-			if err := ioutil.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
+			if err := os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
 				t.Errorf("write test file failed: %s", err)
 			}
 		}
@@ -716,7 +716,7 @@ import (
 	}
 	for _, tt := range tests {
 		if tt.args.filePath != StandardInput && !strings.Contains(tt.args.filePath, "does-not-exist") {
-			if err := ioutil.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
+			if err := os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
 				t.Errorf("write test file failed: %s", err)
 			}
 		}
@@ -1010,7 +1010,7 @@ func main() {
 	}
 
 	for _, tt := range tests {
-		if err := ioutil.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
+		if err := os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
 			t.Errorf("write test file failed: %s", err)
 		}
 
@@ -1160,7 +1160,7 @@ func main() {
 	}
 
 	for _, tt := range tests {
-		if err := ioutil.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
+		if err := os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
 			t.Errorf("write test file failed: %s", err)
 		}
 
@@ -1376,7 +1376,7 @@ func main() {
 	}
 
 	for _, tt := range tests {
-		if err := ioutil.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
+		if err := os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
 			t.Errorf("write test file failed: %s", err)
 		}
 
@@ -1466,7 +1466,7 @@ func test1() {}
 		},
 	}
 	for _, tt := range tests {
-		if err := ioutil.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
+		if err := os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
 			t.Errorf("write test file failed: %s", err)
 		}
 
@@ -1842,7 +1842,7 @@ import (
 	}
 	for _, tt := range tests {
 		if tt.args.filePath != StandardInput && !strings.Contains(tt.args.filePath, "does-not-exist") {
-			if err := ioutil.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
+			if err := os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644); err != nil {
 				t.Errorf("write test file failed: %s", err)
 			}
 		}


### PR DESCRIPTION
This PR replaces usages functions from `io/ioutil` with `os` and `io`. Package `ioutil` is deprecated since [go 1.16](https://pkg.go.dev/io/ioutil).