### PR TITLE
Get rid of mitchellh/go-homedir package dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,31 +21,31 @@ build-all-lint: build-lint-windows-386 build-lint-windows-amd64 build-lint-macos
 
 .PHONY: build-lint-windows-386
 build-lint-windows-386:
-	GOOS=windows GOARCH=386 go build -tags linter -o bin/windows-386/goimportsreviserlint.exe ./linter
+	GOOS=windows GOARCH=386 go build -tags linter,osusergo -o bin/windows-386/goimportsreviserlint.exe ./linter
 
 .PHONY: build-lint-windows-amd64
 build-lint-windows-amd64:
-	GOOS=windows GOARCH=amd64 go build -tags linter -o bin/windows-amd64/goimportsreviserlint.exe ./linter
+	GOOS=windows GOARCH=amd64 go build -tags linter,osusergo -o bin/windows-amd64/goimportsreviserlint.exe ./linter
 
 .PHONY: build-lint-macos-amd64
 build-lint-macos-amd64:
-	GOOS=darwin GOARCH=amd64 go build -tags linter -o bin/macos-amd64/goimportsreviserlint ./linter
+	GOOS=darwin GOARCH=amd64 go build -tags linter,osusergo -o bin/macos-amd64/goimportsreviserlint ./linter
 
 .PHONY: build-lint-macos-arm64
 build-lint-macos-arm64:
-	GOOS=darwin GOARCH=arm64 go build -tags linter -o bin/macos-arm64/goimportsreviserlint ./linter
+	GOOS=darwin GOARCH=arm64 go build -tags linter,osusergo -o bin/macos-arm64/goimportsreviserlint ./linter
 
 .PHONY: build-lint-linux-386
 build-lint-linux-386:
-	GOOS=linux GOARCH=386 go build -tags linter -o bin/linux-386/goimportsreviserlint ./linter
+	GOOS=linux GOARCH=386 go build -tags linter,osusergo -o bin/linux-386/goimportsreviserlint ./linter
 
 .PHONY: build-lint-linux-amd64
 build-lint-linux-amd64:
-	GOOS=linux GOARCH=amd64 go build -tags linter -o bin/linux-amd64/goimportsreviserlint ./linter
+	GOOS=linux GOARCH=amd64 go build -tags linter,osusergo -o bin/linux-amd64/goimportsreviserlint ./linter
 
 .PHONY: build-lint-linux-arm64
 build-lint-linux-arm64:
-	GOOS=linux GOARCH=arm64 go build -tags linter -o bin/linux-arm64/goimportsreviserlint ./linter
+	GOOS=linux GOARCH=arm64 go build -tags linter,osusergo -o bin/linux-arm64/goimportsreviserlint ./linter
 
 .PHONY: update-std-package-list
 update-std-package-list:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/incu6us/goimports-reviser/v3
 go 1.18
 
 require (
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/user"
 	"path"
 	"path/filepath"
 	"strings"
 
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 
 	"github.com/incu6us/goimports-reviser/v3/helper"
@@ -278,11 +278,11 @@ func main() {
 	if *isUseCache {
 		hash := md5.Sum([]byte(originPath))
 
-		var home string
-		if home, err = homedir.Dir(); err != nil {
+		u, err := user.Current()
+		if err != nil {
 			log.Fatalf("%+v\n", errors.WithStack(err))
 		}
-		cacheDir := path.Join(home, ".cache", "goimports-reviser")
+		cacheDir := path.Join(u.HomeDir, ".cache", "goimports-reviser")
 		if err = os.MkdirAll(cacheDir, os.ModePerm); err != nil {
 			log.Fatalf("%+v\n", errors.WithStack(err))
 		}


### PR DESCRIPTION
This PR removes `github.com/mitchellh/go-homedir` package dependency by replacing it with `os/user`.

`osusergo` build tag is needed to enforce pure Go implementation for `os/user`. See [doc](https://pkg.go.dev/os/user). 