### PR TITLE
docs: add go install command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Usage of goimports-reviser:
 ```
 
 ## Install
+### With Go
+```bash
+go install -v github.com/incu6us/goimports-reviser/v3@latest
+```
+
 ### With Brew
 ```bash
 brew tap incu6us/homebrew-tap


### PR DESCRIPTION
This adds the go install command to install this program to the GOBIN to document the simplest way to install the program for systems without Homebrew or Snap.