### PR TITLE
Refactor tests: t.Fatal, t.TempDir, t.Parallel

### DIFF
--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestDetermineProjectName(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		projectName string
 		filePath    string
@@ -25,7 +27,7 @@ func TestDetermineProjectName(t *testing.T) {
 				filePath: func() string {
 					dir, err := os.Getwd()
 					if err != nil {
-						panic(err)
+						t.Fatal(err)
 					}
 
 					return dir
@@ -47,7 +49,10 @@ func TestDetermineProjectName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := DetermineProjectName(tt.args.projectName, tt.args.filePath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DetermineProjectName() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/astutil/astutil_test.go
+++ b/pkg/astutil/astutil_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestUsesImport(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		fileData       string
 		path           string
@@ -146,10 +148,12 @@ func main(){
 		},
 	}
 	for _, tt := range tests {
-
+		tt := tt
 		fileData := tt.args.fileData
 
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			fset := token.NewFileSet()
 			f, err := parser.ParseFile(fset, "", []byte(fileData), parser.ParseComments)
 			require.NoError(t, err)
@@ -162,6 +166,8 @@ func main(){
 }
 
 func TestLoadPackageDeps(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		dir      string
 		filename string
@@ -200,7 +206,10 @@ func TestLoadPackageDeps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			f, err := parser.ParseFile(
 				token.NewFileSet(),
 				fmt.Sprintf("%s/%s", tt.args.dir, tt.args.filename),

--- a/pkg/module/error_test.go
+++ b/pkg/module/error_test.go
@@ -3,6 +3,8 @@ package module
 import "testing"
 
 func TestPathIsNotSetError_Error(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		want string
@@ -24,6 +26,8 @@ func TestPathIsNotSetError_Error(t *testing.T) {
 }
 
 func TestUndefinedModuleError_Error(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		want string


### PR DESCRIPTION
- Use [`t.Fatal(err)`](https://pkg.go.dev/testing#T.Fatal) instead of `panic(err)`.
- Make tests run in parallel. Tests in `file_test.go` remain running sequentially.
- Refactor to `T.TempDir` instead of `/tmp`. [`T.TempDir`](https://pkg.go.dev/testing#T.TempDir) automatically deletes the directory at the end of a test.
- Use `filepath.Join(dir, "module.go")` instead of `dir + "/module.go"` to improve portabilify.