### PR TITLE
improve Go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,31 +10,32 @@ on:
 jobs:
 
   build:
-    name: Build
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        go-version: [ 1.18.x, oldstable, stable ]
+
+    runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
 
-    - name: Set up Go 1.18
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.18
-      id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      - name: Get dependencies
+        run: |
+          go mod download
+          go get github.com/go-pg/pg/v9
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        go get github.com/go-pg/pg/v9
-      
-    - name: Test
-      run: go test -race -cover -coverprofile=coverage.txt -covermode=atomic ./...
+      - name: Test
+        run: go test -race -cover -coverprofile=coverage -covermode=atomic ./...
 
-    - name: Coverage
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.txt
+      - name: Coverage
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage
 
-    - name: Build
-      run: go build -v .
+      - name: Build
+        run: go build -v .

--- a/pkg/module/module_test.go
+++ b/pkg/module/module_test.go
@@ -87,8 +87,11 @@ func TestName(t *testing.T) {
 			name: "read empty go.mod",
 			prepareFn: func() string {
 				dir := t.TempDir()
-				_, err := os.Create(filepath.Join(dir, "go.mod"))
+				f, err := os.Create(filepath.Join(dir, "go.mod"))
 				if err != nil {
+					t.Fatal(err)
+				}
+				if err := f.Close(); err != nil {
 					t.Fatal(err)
 				}
 				return dir
@@ -106,6 +109,9 @@ func TestName(t *testing.T) {
 				}
 
 				if _, err := file.WriteString("mod test"); err != nil {
+					t.Fatal(err)
+				}
+				if err := file.Close(); err != nil {
 					t.Fatal(err)
 				}
 				return dir


### PR DESCRIPTION
- Run workflow on the Go `1.18`, `1.19 (oldstable)`, `1.20 (stable)` versions.
- Use Windows tests. Fix `TestName` on this platform (a file must be closed before deleting a directory).
- Update and rearrange actions versions, this enables caching by default.
