### PR TITLE
Replace "%s" with %q; octal literals for file permissions

### DIFF
--- a/main.go
+++ b/main.go
@@ -354,14 +354,14 @@ func resultPostProcess(hasChange bool, deprecatedMessagesCh chan string, originF
 			return
 		}
 
-		if err := os.WriteFile(originFilePath, formattedOutput, 0644); err != nil {
+		if err := os.WriteFile(originFilePath, formattedOutput, 0o644); err != nil {
 			log.Fatalf("failed to write fixed result to file(%s): %+v\n", originFilePath, err)
 		}
 		if *listFileName {
 			fmt.Println(originFilePath)
 		}
 	} else {
-		log.Fatalf(`invalid output "%s" specified`, output)
+		log.Fatalf(`invalid output %q specified`, output)
 	}
 
 	if hasChange && *setExitStatus {

--- a/pkg/std/gen/gen.go
+++ b/pkg/std/gen/gen.go
@@ -71,7 +71,7 @@ func main() {
 
 	filePath := filepath.Join(filepath.Join(currentDir, "pkg/std"), fileName)
 	log.Printf("file path to be updated: %s", filePath)
-	if err := os.WriteFile(filePath, data, 0644); err != nil {
+	if err := os.WriteFile(filePath, data, 0o644); err != nil {
 		log.Fatalf("Failed to write file: %+v\n", err)
 	}
 }

--- a/reviser/dir.go
+++ b/reviser/dir.go
@@ -92,7 +92,7 @@ func (d *SourceDir) walk(options ...SourceFileOption) fs.WalkDirFunc {
 				return fmt.Errorf("failed to fix: %w", err)
 			}
 			if hasChange {
-				if err := os.WriteFile(path, content, 0644); err != nil {
+				if err := os.WriteFile(path, content, 0o644); err != nil {
 					log.Fatalf("failed to write fixed result to file(%s): %+v\n", path, err)
 				}
 			}

--- a/reviser/dir_test.go
+++ b/reviser/dir_test.go
@@ -1,10 +1,11 @@
 package reviser
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const sep = string(os.PathSeparator)
@@ -151,8 +152,4 @@ func TestSourceDir_IsExcluded(t *testing.T) {
 			assert.Equal(tt, test.want, excluded)
 		})
 	}
-}
-
-func join(elem ...string) string {
-	return filepath.Join(elem...)
 }

--- a/reviser/file_test.go
+++ b/reviser/file_test.go
@@ -570,7 +570,7 @@ import "C"
 	}
 	for _, tt := range tests {
 		if tt.args.filePath != StandardInput && !strings.Contains(tt.args.filePath, "does-not-exist") {
-			require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644))
+			require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0o644))
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -716,7 +716,7 @@ import (
 	}
 	for _, tt := range tests {
 		if tt.args.filePath != StandardInput && !strings.Contains(tt.args.filePath, "does-not-exist") {
-			require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644))
+			require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0o644))
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -1009,7 +1009,7 @@ func main() {
 	}
 
 	for _, tt := range tests {
-		require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644))
+		require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0o644))
 
 		t.Run(tt.name, func(t *testing.T) {
 			got, hasChange, err := NewSourceFile(tt.args.projectName, tt.args.filePath).
@@ -1158,7 +1158,7 @@ func main() {
 	}
 
 	for _, tt := range tests {
-		require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644))
+		require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0o644))
 
 		t.Run(tt.name, func(t *testing.T) {
 			got, hasChange, err := NewSourceFile(tt.args.projectName, tt.args.filePath).
@@ -1373,7 +1373,7 @@ func main() {
 	}
 
 	for _, tt := range tests {
-		require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644))
+		require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0o644))
 
 		t.Run(tt.name, func(t *testing.T) {
 			got, hasChange, err := NewSourceFile(tt.args.projectName, tt.args.filePath).
@@ -1462,7 +1462,7 @@ func test1() {}
 		},
 	}
 	for _, tt := range tests {
-		require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644))
+		require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0o644))
 
 		t.Run(tt.name, func(t *testing.T) {
 			got, hasChange, err := NewSourceFile(tt.args.projectName, tt.args.filePath).Fix(WithCodeFormatting)
@@ -1837,7 +1837,7 @@ import (
 	}
 	for _, tt := range tests {
 		if tt.args.filePath != StandardInput && !strings.Contains(tt.args.filePath, "does-not-exist") {
-			require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0644))
+			require.NoError(t, os.WriteFile(tt.args.filePath, []byte(tt.args.fileContent), 0o644))
 		}
 
 		t.Run(tt.name, func(t *testing.T) {

--- a/reviser/import_order.go
+++ b/reviser/import_order.go
@@ -65,7 +65,7 @@ func StringToImportsOrders(s string) (ImportsOrders, error) {
 
 	groups := unique(strings.Split(s, ","))
 	if len(groups) != 4 {
-		return nil, fmt.Errorf(`use this parameters to sort all groups of your imports: "%s"`, defaultImportsOrder)
+		return nil, fmt.Errorf(`use this parameters to sort all groups of your imports: %q`, defaultImportsOrder)
 	}
 
 	var groupOrder []ImportsOrder
@@ -74,7 +74,7 @@ func StringToImportsOrders(s string) (ImportsOrders, error) {
 		switch group {
 		case StdImportsOrder, CompanyImportsOrder, ProjectImportsOrder, GeneralImportsOrder:
 		default:
-			return nil, fmt.Errorf(`unknown order group type: "%s"`, group)
+			return nil, fmt.Errorf(`unknown order group type: %q`, group)
 		}
 
 		groupOrder = append(groupOrder, group)

--- a/reviser/import_order_test.go
+++ b/reviser/import_order_test.go
@@ -1,0 +1,44 @@
+package reviser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringToImportsOrder(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		importsOrder string
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr string
+	}{
+		{
+			name:    "invalid groups count",
+			args:    args{importsOrder: "std,general"},
+			wantErr: `use this parameters to sort all groups of your imports: "std,general,company,project"`,
+		},
+		{
+			name:    "unknown group",
+			args:    args{importsOrder: "std,general,company,group"},
+			wantErr: `unknown order group type: "group"`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := StringToImportsOrders(tt.args.importsOrder)
+
+			assert.Nil(t, got)
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
This PR:
- replaces `"%s"` with `%q` https://pkg.go.dev/fmt#hdr-Printing;
- replaces `0644` with `0o644` https://go.dev/ref/spec#Integer_literals ;
- removes unused function `join`;
- adds the test for `StringToImportsOrders`.