### PR TITLE
Refactor to switch-case; decrease indentation

### DIFF
--- a/main.go
+++ b/main.go
@@ -344,11 +344,12 @@ func resultPostProcess(hasChange bool, deprecatedMessagesCh chan string, originF
 		printDeprecations(deprecatedMessagesCh)
 		return
 	}
-	if hasChange && *listFileName && output != "write" {
+	switch {
+	case hasChange && *listFileName && output != "write":
 		fmt.Println(originFilePath)
-	} else if output == "stdout" || originFilePath == reviser.StandardInput {
+	case output == "stdout" || originFilePath == reviser.StandardInput:
 		fmt.Print(string(formattedOutput))
-	} else if output == "file" || output == "write" {
+	case output == "file" || output == "write":
 		if !hasChange {
 			printDeprecations(deprecatedMessagesCh)
 			return
@@ -360,7 +361,7 @@ func resultPostProcess(hasChange bool, deprecatedMessagesCh chan string, originF
 		if *listFileName {
 			fmt.Println(originFilePath)
 		}
-	} else {
+	default:
 		log.Fatalf(`invalid output %q specified`, output)
 	}
 

--- a/reviser/file.go
+++ b/reviser/file.go
@@ -457,9 +457,9 @@ func (f *SourceFile) parseImports(file *ast.File) (map[string]*commentsMetadata,
 	shouldUseAliasForVersionSuffix := f.shouldUseAliasForVersionSuffix
 
 	var packageImports map[string]string
-	var err error
 
 	if shouldRemoveUnusedImports || shouldUseAliasForVersionSuffix {
+		var err error
 		packageImports, err = astutil.LoadPackageDependencies(path.Dir(f.filePath), astutil.ParseBuildTag(file))
 		if err != nil {
 			return nil, err
@@ -467,38 +467,36 @@ func (f *SourceFile) parseImports(file *ast.File) (map[string]*commentsMetadata,
 	}
 
 	for _, decl := range file.Decls {
-		switch decl.(type) {
-		case *ast.GenDecl:
-			dd := decl.(*ast.GenDecl)
-			if isSingleCgoImport(dd) {
+		dd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		if isSingleCgoImport(dd) || dd.Tok != token.IMPORT {
+			continue
+		}
+		for _, spec := range dd.Specs {
+			importSpec := spec.(*ast.ImportSpec)
+
+			if shouldRemoveUnusedImports && !astutil.UsesImport(
+				file, packageImports, strings.Trim(importSpec.Path.Value, `"`),
+			) {
 				continue
 			}
-			if dd.Tok == token.IMPORT {
-				for _, spec := range dd.Specs {
-					var importSpecStr string
-					importSpec := spec.(*ast.ImportSpec)
 
-					if shouldRemoveUnusedImports && !astutil.UsesImport(
-						file, packageImports, strings.Trim(importSpec.Path.Value, `"`),
-					) {
-						continue
-					}
-
-					if importSpec.Name != nil {
-						importSpecStr = strings.Join([]string{importSpec.Name.String(), importSpec.Path.Value}, " ")
-					} else {
-						if shouldUseAliasForVersionSuffix {
-							importSpecStr = setAliasForVersionedImportSpec(importSpec, packageImports)
-						} else {
-							importSpecStr = importSpec.Path.Value
-						}
-					}
-
-					importsWithMetadata[importSpecStr] = &commentsMetadata{
-						Doc:     importSpec.Doc,
-						Comment: importSpec.Comment,
-					}
+			var importSpecStr string
+			if importSpec.Name != nil {
+				importSpecStr = strings.Join([]string{importSpec.Name.String(), importSpec.Path.Value}, " ")
+			} else {
+				if shouldUseAliasForVersionSuffix {
+					importSpecStr = setAliasForVersionedImportSpec(importSpec, packageImports)
+				} else {
+					importSpecStr = importSpec.Path.Value
 				}
+			}
+
+			importsWithMetadata[importSpecStr] = &commentsMetadata{
+				Doc:     importSpec.Doc,
+				Comment: importSpec.Comment,
 			}
 		}
 	}

--- a/reviser/file.go
+++ b/reviser/file.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"


### PR DESCRIPTION
This PR does refactorings:
- change `if-else if-else` with `switch-case`;
- change `switch` with single case to `if`;
- decrease indentation by using `continue`.