### PR TITLE
fix: filed to fix directory when using ./... path

### DIFF
--- a/main.go
+++ b/main.go
@@ -269,7 +269,7 @@ func main() {
 	if _, ok := reviser.IsDir(originPath); ok {
 		err := reviser.NewSourceDir(originProjectName, originPath, *isRecursive, excludes).Fix(options...)
 		if err != nil {
-			log.Fatalf("Failed to fix directory: %+v\n", err)
+			log.Fatalf("Failed to fix directory %s: %+v\n", originPath, err)
 		}
 		return
 	}

--- a/pkg/astutil/astutil.go
+++ b/pkg/astutil/astutil.go
@@ -64,7 +64,8 @@ func UsesImport(f *ast.File, packageImports PackageImports, importPath string) b
 }
 
 // LoadPackageDependencies will return all package's imports with it names:
-// 		key - package(ex.: github/pkg/errors), value - name(ex.: errors)
+//
+//	key - package(ex.: github/pkg/errors), value - name(ex.: errors)
 func LoadPackageDependencies(dir, buildTag string) (PackageImports, error) {
 	cfg := &packages.Config{
 		Dir:   dir,

--- a/pkg/astutil/testdata/testdata_with_deprecated_build_tag.go
+++ b/pkg/astutil/testdata/testdata_with_deprecated_build_tag.go
@@ -1,4 +1,5 @@
-//+build test
+//go:build test
+// +build test
 
 package testdata
 

--- a/reviser/dir.go
+++ b/reviser/dir.go
@@ -34,12 +34,17 @@ type SourceDir struct {
 }
 
 func NewSourceDir(projectName string, path string, isRecursive bool, excludes string) *SourceDir {
-	if path == recursivePath {
-		isRecursive = true
-	}
 	patterns := make([]string, 0)
+
 	// get the absolute path
 	absPath, err := filepath.Abs(path)
+
+	// if path is recursive, then we need to remove the "/..." suffix
+	if path == recursivePath {
+		isRecursive = true
+		absPath = strings.TrimSuffix(absPath, "/...")
+	}
+
 	if err == nil {
 		segs := strings.Split(excludes, ",")
 		for _, seg := range segs {

--- a/reviser/dir_test.go
+++ b/reviser/dir_test.go
@@ -10,6 +10,16 @@ import (
 
 const sep = string(os.PathSeparator)
 
+func TestNewSourceDir(t *testing.T) {
+	t.Run("should generate source dir from recursive path", func(tt *testing.T) {
+		dir := NewSourceDir("project", recursivePath, false, "")
+		assert.Equal(tt, "project", dir.projectName)
+		assert.NotContains(tt, dir.dir, "/...")
+		assert.Equal(tt, true, dir.isRecursive)
+		assert.Equal(tt, 0, len(dir.excludePatterns))
+	})
+}
+
 func TestSourceDir_Fix(t *testing.T) {
 	testFile := "testdata/dir/dir1/file1.go"
 


### PR DESCRIPTION
## Description

From last release `v3.4.0` when using the next command `goimports-reviser ./...` it throws and error from filepath that provided path is not a valid folder.

This fix removes the suffix `/...` from the absolute path to get the real valid folder that should be formatted. 

## Related Issues

https://github.com/incu6us/goimports-reviser/issues/123
https://github.com/incu6us/goimports-reviser/issues/118
https://github.com/incu6us/goimports-reviser/issues/93