### PR TITLE
fix bug `list-diff` support dir mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -269,7 +269,7 @@ func main() {
 	close(deprecatedMessagesCh)
 
 	if _, ok := reviser.IsDir(originPath); ok {
-		err := reviser.NewSourceDir(originProjectName, originPath, *isRecursive, excludes).Fix(options...)
+		err := reviser.NewSourceDir(originProjectName, originPath, *isRecursive, *listFileName, excludes).Fix(options...)
 		if err != nil {
 			log.Fatalf("Failed to fix directory %s: %+v\n", originPath, err)
 		}

--- a/reviser/dir.go
+++ b/reviser/dir.go
@@ -27,13 +27,14 @@ var (
 
 // SourceDir to validate and fix import
 type SourceDir struct {
-	projectName     string
-	dir             string
-	isRecursive     bool
-	excludePatterns []string // see filepath.Match
+	projectName        string
+	dir                string
+	isRecursive        bool
+	shouldListFileName bool
+	excludePatterns    []string // see filepath.Match
 }
 
-func NewSourceDir(projectName string, path string, isRecursive bool, excludes string) *SourceDir {
+func NewSourceDir(projectName string, path string, isRecursive, shouldListFileName bool, excludes string) *SourceDir {
 	patterns := make([]string, 0)
 
 	// get the absolute path
@@ -62,10 +63,11 @@ func NewSourceDir(projectName string, path string, isRecursive bool, excludes st
 		}
 	}
 	return &SourceDir{
-		projectName:     projectName,
-		dir:             absPath,
-		isRecursive:     isRecursive,
-		excludePatterns: patterns,
+		projectName:        projectName,
+		dir:                absPath,
+		isRecursive:        isRecursive,
+		shouldListFileName: shouldListFileName,
+		excludePatterns:    patterns,
 	}
 }
 
@@ -97,6 +99,9 @@ func (d *SourceDir) walk(options ...SourceFileOption) fs.WalkDirFunc {
 				return fmt.Errorf("failed to fix: %w", err)
 			}
 			if hasChange {
+				if d.shouldListFileName {
+					fmt.Println(path)
+				}
 				if err := os.WriteFile(path, content, 0o644); err != nil {
 					log.Fatalf("failed to write fixed result to file(%s): %+v\n", path, err)
 				}

--- a/reviser/dir_test.go
+++ b/reviser/dir_test.go
@@ -12,10 +12,11 @@ const sep = string(os.PathSeparator)
 
 func TestNewSourceDir(t *testing.T) {
 	t.Run("should generate source dir from recursive path", func(tt *testing.T) {
-		dir := NewSourceDir("project", recursivePath, false, "")
+		dir := NewSourceDir("project", recursivePath, false, false, "")
 		assert.Equal(tt, "project", dir.projectName)
 		assert.NotContains(tt, dir.dir, "/...")
 		assert.Equal(tt, true, dir.isRecursive)
+		assert.Equal(tt, false, dir.shouldListFileName)
 		assert.Equal(tt, 0, len(dir.excludePatterns))
 	})
 }
@@ -99,7 +100,7 @@ func main() {
 
 			exec(tt, func(ttt *testing.T) error {
 				// executing SourceDir.Fix
-				err := NewSourceDir(test.args.project, test.args.path, true, test.args.excludes).Fix()
+				err := NewSourceDir(test.args.project, test.args.path, true, true, test.args.excludes).Fix()
 				assert.NoError(tt, err)
 				// read new content
 				content, err := os.ReadFile(testFile)
@@ -158,7 +159,7 @@ func TestSourceDir_IsExcluded(t *testing.T) {
 	for _, test := range tests {
 		args := test.args
 		t.Run(test.name, func(tt *testing.T) {
-			excluded := NewSourceDir(args.project, args.path, true, args.excludes).isExcluded(args.testPath)
+			excluded := NewSourceDir(args.project, args.path, true, true, args.excludes).isExcluded(args.testPath)
 			assert.Equal(tt, test.want, excluded)
 		})
 	}


### PR DESCRIPTION
Hi, everyone.

I want to integrate goimports-reviser into our CI/CD to ensure that code gating will fail when the import ordering is not as expected.

But I found that list-diff flag is not work when a recursive path (./...) is given.

I am making a PR to fix this bug. But I have one question.

    What is the right behavior when `list-diff` flag is given?
    Refact code and print file path? or only print file path?

From what I remember, when you run the goimports -l command, it only prints the file path without refactoring the code.

I don't know what behavior is expected here for goimports-reviser.

#139 