### PR TITLE
fix: use filepath.Dir instead of path.Dir

### DIFF
--- a/reviser/file.go
+++ b/reviser/file.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -438,7 +439,7 @@ func (f *SourceFile) parseImports(file *ast.File) (map[string]*commentsMetadata,
 
 	if shouldRemoveUnusedImports || shouldUseAliasForVersionSuffix {
 		var err error
-		packageImports, err = astutil.LoadPackageDependencies(path.Dir(f.filePath), astutil.ParseBuildTag(file))
+		packageImports, err = astutil.LoadPackageDependencies(filepath.Dir(f.filePath), astutil.ParseBuildTag(file))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
see https://stackoverflow.com/questions/12132125/golang-cross-platform-path-dir

it is not work in windows when use flag -rm-unused