### PR TITLE
Allow multiple targets on command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ goimports-reviser -rm-unused -set-alias -format -recursive reviser
 goimports-reviser -rm-unused -set-alias -format ./...
 ```
 
+You can also apply rules to multiple targets:
+```bash
+goimports-reviser -rm-unused -set-alias -format ./reviser/reviser.go ./pkg/...
+```
+
 ### Example, to configure it with JetBrains IDEs (via file watcher plugin):
 ![example](./images/image.png)
 

--- a/main.go
+++ b/main.go
@@ -292,14 +292,10 @@ func main() {
 		originPaths = append(originPaths, filePath)
 	}
 
-	var originPath string
 	if len(originPaths) == 0 || (len(originPaths) == 1 && originPaths[0] == "-") {
 		originPaths[0] = reviser.StandardInput
-	}
-
-	for _, originPath = range originPaths {
-		if err := validateRequiredParam(originPath); err != nil {
-			fmt.Printf("%s\n\n", err)
+		if err := validateRequiredParam(originPaths[0]); err != nil {
+			log.Printf("%s\n\n", err)
 			printUsage()
 			os.Exit(1)
 		}
@@ -347,18 +343,17 @@ func main() {
 		options = append(options, reviser.WithImportsOrder(order))
 	}
 
-	originProjectName, err := helper.DetermineProjectName(projectName, originPath, helper.OSGetwdOption)
-	if err != nil {
-		fmt.Printf("%s\n\n", err)
-		printUsage()
-		os.Exit(1)
-	}
-
 	close(deprecatedMessagesCh)
 	var hasChange bool
 	log.Printf("Paths: %v\n", originPaths)
-	for _, originPath = range originPaths {
+	for _, originPath := range originPaths {
 		log.Printf("Processing %s\n", originPath)
+		originProjectName, err := helper.DetermineProjectName(projectName, originPath, helper.OSGetwdOption)
+		if err != nil {
+			log.Printf("Could not determine project name for path %s: %s\n\n", originPath, err)
+			printUsage()
+			os.Exit(1)
+		}
 		if _, ok := reviser.IsDir(originPath); ok {
 			if *listFileName {
 				unformattedFiles, err := reviser.NewSourceDir(originProjectName, originPath, *isRecursive, excludes).Find(options...)

--- a/main.go
+++ b/main.go
@@ -206,6 +206,14 @@ func printUsage() {
 	flag.PrintDefaults()
 }
 
+func printUsageAndExit(err error) {
+	printUsage()
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+	os.Exit(0)
+}
+
 func getBuildInfo() *debug.BuildInfo {
 	bi, ok := debug.ReadBuildInfo()
 	if !ok {
@@ -295,9 +303,7 @@ func main() {
 	if len(originPaths) == 0 || (len(originPaths) == 1 && originPaths[0] == "-") {
 		originPaths[0] = reviser.StandardInput
 		if err := validateRequiredParam(originPaths[0]); err != nil {
-			log.Printf("%s\n\n", err)
-			printUsage()
-			os.Exit(1)
+			printUsageAndExit(err)
 		}
 	}
 
@@ -336,9 +342,7 @@ func main() {
 	if importsOrder != "" {
 		order, err := reviser.StringToImportsOrders(importsOrder)
 		if err != nil {
-			fmt.Printf("%s\n\n", err)
-			printUsage()
-			os.Exit(1)
+			printUsageAndExit(err)
 		}
 		options = append(options, reviser.WithImportsOrder(order))
 	}
@@ -350,9 +354,7 @@ func main() {
 		log.Printf("Processing %s\n", originPath)
 		originProjectName, err := helper.DetermineProjectName(projectName, originPath, helper.OSGetwdOption)
 		if err != nil {
-			log.Printf("Could not determine project name for path %s: %s\n\n", originPath, err)
-			printUsage()
-			os.Exit(1)
+			printUsageAndExit(fmt.Errorf("Could not determine project name for path %s: %s", originPath, err))
 		}
 		if _, ok := reviser.IsDir(originPath); ok {
 			if *listFileName {

--- a/main.go
+++ b/main.go
@@ -206,6 +206,8 @@ func printUsage() {
 	flag.PrintDefaults()
 }
 
+// printUsageAndExit prints usage and exits with status 0
+// if err is nil, otherwise it prints the error and exits with status 1
 func printUsageAndExit(err error) {
 	printUsage()
 	if err != nil {


### PR DESCRIPTION
This addresses https://github.com/incu6us/goimports-reviser/issues/96

- iterate over the list of remaining arguments treating each as an origin path

- defer printing deprecation warnings until after all paths are processed

- print deprecation warnings to stderr, not stdout