### PR TITLE
fix: display path on error

### DIFF
--- a/reviser/dir.go
+++ b/reviser/dir.go
@@ -135,7 +135,7 @@ func (d *SourceDir) walk(callback walkCallbackFunc, options ...SourceFileOption)
 		if isGoFile(path) && !dirEntry.IsDir() && !d.isExcluded(path) {
 			content, _, hasChange, err := NewSourceFile(d.projectName, path).Fix(options...)
 			if err != nil {
-				return fmt.Errorf("failed to fix: %w", err)
+				return fmt.Errorf("failed to fix %s: %w", path, err)
 			}
 			return callback(hasChange, path, content)
 		}


### PR DESCRIPTION
fix error is useless when it occurs as path information is missing. This PR fixes that

helps with https://github.com/incu6us/goimports-reviser/issues/162