### PR TITLE
release linux arm64 binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     ldflags:
       - -s -w -X "main.Tag={{ .Tag }}" -X "main.Commit={{ .FullCommit }}" -X "main.SourceURL={{ .GitURL }}" -X "main.GoVersion={{ .Env.GO_VERSION }}"
 


### PR DESCRIPTION
Hi, Although there is support for linux arm through go install, the release binaries lack the arm packaged binary.
I added the feature in go releaser.